### PR TITLE
Implement LArPixHDF5Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
  pytest
  ``` 
 
+## CI [![Build Status](https://travis-ci.org/peter-madigan/reco3d.svg?branch=master)](https://travis-ci.org/peter-madigan/reco3d)
+
 ## Execution
 The basic execution of a `reco3d` program involves a `reco3d.Manager`, along with an
 assortment of `reco3d.processes` and `reco3d.resources`. Broadly speaking, their roles in the
@@ -114,7 +116,8 @@ standard logging handlers, the `reco3d.tools.logging` module contains a `Logging
 The `LoggingTool` acts as a wrapper class for the python `Logger` object. All `LoggingTool`
 objects will provide `info()`, `warning()`, `error()`, `critical()`, and `debug()` methods.
 Configuring `StreamHandlers`, `FileHandlers`, and `Formatters` along with log levels will be
-performed through the `OptionsTool` argument passed into the `LoggingTool` at initialization.
+performed through the `OptionsTool` argument passed into the `LoggingTool` at initialization. Most
+base classes provide access to a logger object for inheriting classes.
 
 ### Map of included types with inheritance
 As of July 2018:
@@ -124,6 +127,8 @@ reco3d --- types --- basic_types --- * Empty *
         |         |- larpix_types --- Hit(object)
         |                          |- HitCollection(object)
         |                          |- Event(HitCollection)
+        |                          |- Track(HitCollection)
+        |                          |- Shower(HitCollection)
         |
         |- managers --- Manager(object)
         |            |- ResourceManager(object)
@@ -137,9 +142,7 @@ reco3d --- types --- basic_types --- * Empty *
         |
         |- converters --- basic_converters --- Converter(object)
         |              |
-        |              |- larpix_converters --- SerialConverter(Converter)
-        |                                    |- HDF5Converter(Converter)
-        |                                    |- JSONConverter(Converter)
+        |              |- larpix_converters --- LArPixHDF5Converter(Converter)
         |
         |- processes --- basic_processes --- Process(object)
         |             |

--- a/reco3d/converters/basic_converters.py
+++ b/reco3d/converters/basic_converters.py
@@ -1,3 +1,26 @@
+'''
+This module contains the base class for Converter-type objects
+
+Converters handle data IO to external services such as file formats, guis, etc, and are
+instantiated by Resources.
+
+Each Converter class has the following methods and attributes:
+ - a `req_opts` attribute that is a list of required option keys, if an OptionTool is passed into
+ the Converter without all of the keys listed in `req_opts` a RunTimeError is raise
+ - a `default_opts` attribute that is a dict of all options with default values
+ - an `open()` method that can be called by the parent Resource during the config stage
+ - a `close()` method that can be called by the parent Resource during the cleanup stage
+ - a `read(dtype, loc=None)` method to read data from external service*
+ - a `write(data, loc=None)` method to write data to the external service*
+
+Inheritance from the basic_converters.Converter class provides:
+ - a `logger` object of type `LoggingTool`
+ - an `options` object of type `OptionsTool`
+
+*Note: There is no specification for the `loc` of data, however the mapping should be clearly
+documented in the implementation and unique for each data object.
+
+'''
 from reco3d.tools.logging import LoggingTool
 
 class Converter(object):
@@ -9,23 +32,24 @@ class Converter(object):
         self.options.check_req(self.req_opts)
         self.options.set_default(self.default_opts)
         self.logger = LoggingTool(options.get('LoggingTool'), name=self.__class__.__name__)
-        self.logger('{} initialized'.format(self))
 
     def open(self):
-        # open converter (typically occurs during config phase)
+        ''' Open converter (typically occurs during config phase) '''
         pass
 
     def close(self):
-        # close converter (typically occurs during cleanup phase)
+        ''' Close converter (typically occurs during cleanup phase) '''
         pass
 
-    def read(self, loc, id=None):
-        # looking at loc, return objects that match id
+    def read(self, dtype, loc=None):
+        ''' Looking at `loc`, return objects that match type. If `loc` is None, return "next" object '''
         return None
 
     def write(self, data, loc=None):
-        # write data to location. If None specified, append to end of dataset
-        # return True if successful, False if not
+        '''
+        Write data to location. If None specified, append to end of dataset
+        Return True if successful, False if not
+        '''
         return False
 
 

--- a/reco3d/converters/larpix_converters.py
+++ b/reco3d/converters/larpix_converters.py
@@ -1,0 +1,382 @@
+'''
+This module contains converters used by LArPix reconstruction and analysis
+
+The module requirements are `h5py` and `numpy`.
+
+'''
+from reco3d.converters.basic_converters import Converter
+import reco3d.tools.python as reco3d_pytools
+import reco3d.types as reco3d_types
+import h5py
+import numpy as np
+
+region_ref = h5py.special_dtype(ref=h5py.RegionReference)
+
+class LArPixHDF5Converter(Converter):
+    '''
+    A Converter-type class for handling two-way communication with an HDF5 file used for reconstruction
+    options:
+        - `"filename"`: path to file
+
+    Locating objects: HDF5 file structure is organized at the top level by object type. Each object type has its own
+    dataset with the naming scheme described by `LArPixHDF5Converter.type_lookup`. Each dataset consists of rows of 
+    numpy arrays described by `dataset_desc`. To lookup/store an object at a specific row index, use `loc=<row idx>`.
+    '''
+    req_opts = Converter.req_opts + ['filename'] # list of required options (raises error if not found)
+    default_opts = reco3d_pytools.combine_dicts(Converter.default_opts, {}) # list of option arguments with default values
+
+    type_lookup = {
+        reco3d_types.Hit : 'hits',
+        reco3d_types.Event : 'events',
+        reco3d_types.Track : 'tracks'
+        }
+    rev_type_lookup = dict([(item, key) for key, item in type_lookup.items()])
+
+    dataset_desc = {
+        'info' : None,
+        'hits' : [
+            ('hid', 'i8'),
+            ('px', 'i8'), ('py', 'i8'), ('ts', 'i8'), ('q', 'i8'),
+            ('iochain', 'i8'), ('chipid', 'i8'), ('channelid', 'i8'),
+            ('geom', 'i8'), ('event_ref', region_ref), ('track_ref', region_ref)],
+        'events' : [
+            ('evid', 'i8'), ('track_ref', region_ref), ('hit_ref', region_ref),
+            ('nhit', 'i8'), ('q', 'i8'), ('ts_start', 'i8'), ('ts_end', 'i8')],
+        'tracks' : [
+            ('track_id','i8'), ('event_ref', region_ref), ('hit_ref', region_ref),
+            ('theta', 'f8'),
+            ('phi', 'f8'), ('xp', 'f8'), ('yp', 'f8'), ('nhit', 'i8'),
+            ('q', 'i8'), ('ts_start', 'i8'), ('ts_end', 'i8'),
+            ('sigma_theta', 'f8'), ('sigma_phi', 'f8'), ('sigma_x', 'f8'),
+            ('sigma_y', 'f8')],
+        }
+
+    def __init__(self, options):
+        super().__init__(options)
+        self.filename = self.options['filename']
+        self.is_open = False
+        self.datafile = None
+        self.read_idx = dict([(dset_name, 0) for dset_name in self.rev_type_lookup])
+        self.write_idx = dict([(dset_name, 0) for dset_name in self.rev_type_lookup])
+        
+        self.logger.debug('{} initialized'.format(self))
+
+    def open(self): # Converter method
+        '''
+        Open converter (typically occurs during config phase)
+        '''
+        if not self.is_open:
+            # open file
+            self.datafile = h5py.File(self.filename)
+            # update write indices to end of arrays
+            for dataset_name in self.datafile.keys():
+                if dataset_name in self.rev_type_lookup.keys():
+                    self.write_idx[dataset_name] = self.datafile[dataset_name].shape[0]
+        self.is_open = True
+        self.logger.debug('{} opened'.format(self))
+
+    def close(self): # Converter method
+        '''
+        Close converter (typically occurs during cleanup phase)
+        '''
+        if self.is_open:
+            self.datafile.close()
+        self.is_open = False
+        self.logger.debug('{} closed'.format(self))
+
+    def read(self, dtype, loc=None): # Converter method
+        '''
+        Looking at loc, return objects that match type
+        If loc is None, return "next" object
+        '''
+        if not dtype in self.type_lookup: return None
+        if not self.is_open:
+            self.open()
+        dset_name = self.type_lookup[dtype]
+
+        if dset_name is 'hits':
+            hit = self.read_hit(loc)
+            return hit
+
+        elif dset_name is 'tracks':
+            track = self.read_track(loc)
+            return track
+
+        elif dset_name is 'events':
+            event = self.read_event(loc)
+            return event
+
+        return None
+
+    def write(self, data, loc=None): # Converter method
+        '''
+        Write data to location. If None specified, append to end of dataset
+        return True if successful, False if not
+        '''
+        if not type(data) in self.type_lookup: return False
+        if not self.is_open:
+            self.open()
+        dset_name = self.type_lookup[type(data)]
+
+        if dset_name is 'hits':
+            self.write_hit(data, loc)
+            return True
+
+        elif dset_name is 'tracks':
+            self.write_track(data, loc)
+            return True
+
+        elif dset_name is 'events':
+            self.write_event(data, loc)
+            return True
+
+        return False
+
+    def create_dataset(self, name):
+        '''
+        Initialize a dataset with name
+        '''
+        if not name in self.datafile.keys():
+            self.datafile.create_dataset(name, (0,), maxshape=(None,),
+                                         dtype=self.dataset_desc[name])
+
+    def read_hit(self, loc):
+        '''
+        Return hit at index specified by loc.
+        If loc is None, return hit at current index and increment index
+        '''
+        dset_name = self.type_lookup[reco3d_types.Hit]
+        read_idx = loc
+        if read_idx is None:
+            read_idx = self.read_idx[dset_name]
+            self.read_idx[dset_name] += 1
+
+        data = self.datafile[dset_name][read_idx]
+        hit = self.hdf5_to_reco3d_type(reco3d_types.Hit, data)
+        return hit
+
+    def read_track(self, loc):
+        '''
+        Return track at index specified by loc.
+        If loc is None, return track at current index and increment index
+        '''
+        dset_name = self.type_lookup[reco3d_types.Track]
+        read_idx = loc
+        if read_idx is None:
+            read_idx = self.read_idx[dset_name]
+            self.read_idx[dset_name] += 1
+
+        data = self.datafile[dset_name][read_idx]
+        track = self.hdf5_to_reco3d_type(reco3d_types.Track, data)
+        return track
+
+    def read_event(self, loc):
+        '''
+        Return event at index specified by loc
+        If loc is None, return event at current index and increment index
+        '''
+        dset_name = self.type_lookup[reco3d_types.Event]
+        read_idx = loc
+        if read_idx is None:
+            read_idx = self.read_idx[dset_name]
+            self.read_idx[dset_name] += 1
+
+        data = self.datafile[dset_name][read_idx]
+        event = self.hdf5_to_reco3d_type(reco3d_types.Event, data)
+        return event
+
+    def write_obj(self, obj, loc, **kwargs):
+        '''
+        Write an object to a particular location
+        If loc is larger than current array size, resize array accordingly
+        Returns row index of object
+        '''
+        write_data = self.reco3d_type_to_hdf5(obj, **kwargs)
+        if write_data is None: raise TypeError('could not convert data type to array')
+        dset_name = self.type_lookup[type(obj)]
+
+        if not dset_name in self.datafile.keys():
+            self.create_dataset(dset_name)
+
+        write_idx = loc
+        if write_idx is None:
+            write_idx = self.write_idx[dset_name]
+            self.write_idx[dset_name] += 1
+
+        if self.datafile[dset_name].shape[0] <= write_idx:
+            self.datafile[dset_name].resize(write_idx + 1, axis=0)
+
+        self.datafile[dset_name][write_idx] = write_data
+        return write_idx
+
+    def write_hit(self, hit, loc, event_ref=None, track_ref=None):
+        ''' Write a hit to row index specified by `loc` '''
+        return self.write_obj(hit, loc, event_ref=event_ref, track_ref=track_ref)
+
+    def write_track(self, track, loc, event_ref=None, hit_ref=None):
+        ''' Write a track at row index specified by `loc` '''
+        # write track in correct location with uninitialized references
+        track_dset_name = self.type_lookup[type(track)]
+        track_idx = loc
+        if loc is None:
+            track_idx = self.write_idx[track_dset_name]
+            self.write_idx[track_dset_name] += 1
+        track_idx = self.write_obj(track, track_idx, event_ref=event_ref, hit_ref=hit_ref)
+        track_ref = self.datafile[track_dset_name].regionref[track_idx]
+
+        if not hit_ref is None: return track_idx
+        # store hits if no hit_ref is given
+
+        if hit_ref is None and len(track.hits) > 0:
+            # store hits
+            hit_idcs = []
+            for hit in track.hits: hit_idcs += [self.write_hit(hit, None, event_ref=None, track_ref=track_ref)]
+            hit_dset_name = self.type_lookup[type(track.hits[0])]
+            if len(track.hits) > 0:
+                hit_ref = self.datafile[hit_dset_name].regionref[hit_idcs]
+            else:
+                hit_ref = None
+            # re-store track
+            track_idx = self.write_obj(track, track_idx, event_ref=event_ref, hit_ref=hit_ref)
+
+        return track_idx
+    
+    def write_event(self, event, loc, track_ref=None, hit_ref=None):
+        ''' Write an event at row index specified by `loc` '''
+        # write event in correct location with uninitialized references
+        event_dset_name = self.type_lookup[type(event)]
+        event_idx = loc
+        if event_idx is None: 
+            event_idx = self.write_idx[event_dset_name]
+            self.write_idx[event_dset_name] += 1
+        event_idx = self.write_obj(event, event_idx, track_ref=track_ref, hit_ref=hit_ref)
+        event_ref = self.datafile[event_dset_name].regionref[event_idx]
+
+        if not track_ref is None and not hit_ref is None: return event_idx
+        # store hits and tracks if none are specified
+
+        if hit_ref is None:
+            # store hits
+            hit_idcs = []
+            for hit in event.hits: hit_idcs += [self.write_hit(hit, None, event_ref=event_ref, track_ref=track_ref)]
+            hit_dset_name = self.type_lookup[type(event.hits[0])]
+            if len(event.hits) > 0:
+                hit_ref = self.datafile[hit_dset_name].regionref[hit_idcs]
+            else:
+                hit_ref = None
+            # re-store event
+            event_idx = self.write_obj(event, event_idx, track_ref=track_ref, hit_ref=hit_ref)
+
+        if track_ref is None:
+            # store tracks
+            track_idcs = []
+            tracks = [reco_obj for reco_obj in event.reco_objs if type(reco_obj) is reco3d_types.Track]
+            if len(tracks) > 0 and track_ref is None:
+                track_dset_name = self.type_lookup[type(tracks[0])]
+                for track in tracks:
+                    # find hits associated with track
+                    hit_idcs = []
+                    for hit in track.hits: hit_idcs += [self.find(hit, hit_ref)]
+                    track_hit_ref = self.datafile[hit_dset_name].regionref[hit_idcs]
+                    # write track with references
+                    track_idx = self.write_obj(track, None, event_ref=event_ref, hit_ref=track_hit_ref)
+                    track_idcs += [track_idx]
+                    # write hits with references
+                    hit_track_ref = self.datafile[track_dset_name].regionref[track_idx]
+                    for hit_idx, hit in zip(hit_idcs, track.hits):
+                        self.write_hit(hit, hit_idx, event_ref=event_ref, track_ref=hit_track_ref)
+            if len(tracks) > 0:
+                track_ref = self.datafile[track_dset_name].regionref[track_idcs]
+            else:
+                track_ref = None
+            # re-store event
+            event_idx = self.write_obj(event, event_idx, track_ref=track_ref, hit_ref=hit_ref)
+        return event_idx
+
+    def find(self, obj, search_region=None):
+        '''
+        Look for objects that match data object in a region.
+        Return index of row that matches or None, if it can't be found
+        '''
+        if not type(obj) in self.type_lookup.keys(): return None
+        dset_name = self.type_lookup[type(obj)]
+        region = search_region
+        if region is None:
+            # search all data
+            region = self.datafile[dset_name].regionref[:]
+        elif isinstance(region, list) or isinstance(region, slice) or isinstance(region, int):
+            # search by indices
+            region = self.datafile[dset_name].regionref[search_region]
+        elif isinstance(region, h5py.RegionReference):
+            # search by reference
+            region = region
+        else:
+            raise ValueError('cannot search with region type')
+
+        for row_idx, row_data in enumerate(self.datafile[dset_name][region]):
+            obj_data = self.hdf5_to_reco3d_type(type(obj), row_data)
+            if obj_data == obj: return row_idx
+        return None
+
+    def reco3d_type_to_hdf5(self, reco3d_type_obj, **kwargs):
+        '''
+        Automatically generate numpy array used by hdf5
+        Additional attributes can be set (or overridden by kwargs)
+        '''
+        if not type(reco3d_type_obj) in self.type_lookup.keys():
+            return None
+        data_dict = vars(reco3d_type_obj).copy()
+        dataset_name = self.type_lookup[type(reco3d_type_obj)]
+        for value_name, value in kwargs.items():
+            data_dict[value_name] = value
+        self.fill_empty_dict(data_dict, dataset_name)
+        data_tuple = tuple(data_dict[entry_desc[0]] for entry_desc in \
+                               self.dataset_desc[dataset_name])
+        return np.array(data_tuple, dtype=self.dataset_desc[dataset_name])
+
+    @classmethod
+    def fill_empty_dict(cls, data_dict, dataset_name):
+        ''' Fill with empty values (if necessary) '''
+        for entry_desc in cls.dataset_desc[dataset_name]:
+            key = entry_desc[0]
+            if not key in data_dict:
+                if entry_desc[1] == region_ref:
+                    data_dict[key] = None
+                else:
+                    data_dict[key] = -9999
+            elif data_dict[key] is None and not entry_desc[1] == region_ref:
+                data_dict[key] = -9999
+
+    def hdf5_to_reco3d_type(self, dtype, data):
+        '''
+        Convert a numpy array into a reco3d type, building references as well
+        '''
+        if not dtype in self.type_lookup.keys():
+            return None
+        dset_name = self.type_lookup[dtype]
+        args_dict = {}
+        for key in data.dtype.names:
+            args_dict[key] = data[key]
+        items_to_add = []
+        for key, value in args_dict.items():
+            if dset_name != 'hits' and type(value) is h5py.RegionReference and value:
+                region = self.datafile[value][value]
+                if key == 'hit_ref':
+                    items_to_add += [('hits', [self.hdf5_to_reco3d_type(\
+                                    reco3d_types.Hit, hit_row) for hit_row in region])]
+                elif key == 'track_ref':
+                    items_to_add += [('reco_objs', [self.hdf5_to_reco3d_type(\
+                            reco3d_types.Track, track_row) for track_row in region])]
+        for key, value in items_to_add: args_dict[key] = value
+        self.replace_default_with_none(args_dict)
+        obj = (dtype)(**args_dict)
+        return obj
+
+    @classmethod
+    def replace_default_with_none(cls, args_dict):
+        '''
+        Fill all instances of -9999 with None
+        '''
+        for key, value in args_dict.items():
+            if value == -9999:
+                args_dict[key] = None

--- a/reco3d/tools/python.py
+++ b/reco3d/tools/python.py
@@ -1,0 +1,12 @@
+'''
+This module contains a variety of useful functions that you may need
+to make python do what you want
+
+'''
+
+def combine_dicts(first_dict, second_dict):
+    ''' Overwrite first_dict with keys and values of second_dict '''
+    new_dict = first_dict.copy()
+    for key, value in second_dict.items():
+        new_dict[key] = value
+    return new_dict

--- a/reco3d/types/__init__.py
+++ b/reco3d/types/__init__.py
@@ -1,1 +1,3 @@
-# empty
+# import all types
+from reco3d.types.basic_types import *
+from reco3d.types.larpix_types import *

--- a/reco3d/types/larpix_types.py
+++ b/reco3d/types/larpix_types.py
@@ -1,2 +1,125 @@
-pass
-# To be implemented
+'''
+This module contains primitive data types used by the LArPix reconstruction
+'''
+
+class Hit(object):
+    ''' The basic primitive type used in larpix-reconstruction represents a single trigger of a larpix channel '''
+
+    def __init__(self, hid, px, py, ts, q, iochain=None, chipid=None, channelid=None, geom=None, **kwargs):
+        self.hid = hid
+        self.px = px
+        self.py = py
+        self.ts = ts
+        self.q = q
+        self.iochain = iochain
+        self.chipid = chipid
+        self.channelid = channelid
+        self.geom = geom
+
+    def __str__(self):
+        string = 'Hit(hid={hid}, px={px}, py={py}, ts={ts}, q={q}, iochain={iochain}, '\
+            'chipid={chipid}, channelid={channelid}, geom={geom})'.format(**vars(self))
+        return string
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+class HitCollection(object):
+    ''' A base class of collected `Hit` types '''
+    def __init__(self, hits, **kwargs):
+        self.hits = hits
+        self.nhit = len(self.hits)
+        self.ts_start = min(self.get_hit_attr('ts'))
+        self.ts_end = max(self.get_hit_attr('ts'))
+        self.q = sum(self.get_hit_attr('q'))
+
+    def __str__(self):
+        string = '{}(hits=[\n\t{}]\n\t)'.format(self.__class__.__name__, \
+            ', \n\t'.join(str(hit) for hit in self.hits))
+        return string
+
+    def __getitem__(self, key):
+        '''
+        Access to hits or hit attr.
+        If key is an int -> returns hit at that index
+        If key in a str -> returns attr value of all hits specified by key
+        If key is a dict -> returns hits with attr values that match dict
+        If key is a list or tuple -> returns hits at indices
+        E.g.
+        hc = HitCollection(hits=[Hit(0,0,0,0), Hit(1,0,0,0), Hit(1,1,0,0)])
+        hc[0] # Hit(0,0,0,0)
+        hc['px'] # [0,1,1]
+        hc[{'px' : 1}] # [Hit(1,0,0,0), Hit(1,1,0,0)]
+        hc[0,1] # [Hit(0,0,0,0), Hit(1,0,0,0)]
+        '''
+        if isinstance(key, int):
+            return self.hits[key]
+        elif isinstance(key, str):
+            return self.get_hit_attr(key)
+        elif isinstance(key, dict):
+            return self.get_hit_match(key)
+        elif isinstance(key, list) or isinstance(key, tuple):
+            return [self.hits[idx] for idx in key]
+
+    def __len__(self):
+        return nhit
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def get_hit_attr(self, attr, default=None):
+        ''' Get a list of the specified attribute from event hits '''
+        if not default is None:
+            return [getattr(hit, attr, default) for hit in self.hits]
+        else:
+            return [getattr(hit, attr) for hit in self.hits]
+
+    def get_hit_match(self, attr_value_dict):
+        '''
+        Returns a list of hits that match the attr_value_dict
+        attr_value_dict = { <hit attribute> : <value of attr>, ...}
+        '''
+        return_list = []
+        for hit in self.hits:
+            if all([getattr(hit, attr) == value for attr, value in \
+                        attr_value_dict.items()]):
+                return_list += [hit]
+        return return_list
+
+class Event(HitCollection):
+    '''
+    A class for a collection of hits associated by the event builder, contains
+    reconstructed objects
+    '''
+    def __init__(self, evid, hits, reco_objs=None, **kwargs):
+        super().__init__(hits)
+        self.evid = evid
+        if reco_objs is None:
+            self.reco_objs = []
+        else:
+            self.reco_objs = reco_objs
+
+    def __str__(self):
+        string = HitCollection.__str__(self)[:-1]
+        string += ', evid={evid}, reco_objs={reco_objs})'.format(\
+            **vars(self))
+        return string
+
+class Track(HitCollection):
+    '''
+    A class representing a reconstructed straight line segment and associated
+    hits
+    '''
+    def __init__(self, hits, theta, phi, xp, yp, vertices=[], cov=None, **kwargs):
+        super().__init__(hits)
+        self.theta = theta
+        self.phi = phi
+        self.xp = xp
+        self.yp = yp
+        self.vertices = []
+        self.cov = cov
+
+class Shower(HitCollection):
+    ''' A class representing a shower '''
+    pass
+# etc

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,9 @@ setup(
         classifiers=[
             'Development Status :: 2 - Pre-Alpha',
             'Intended Audience :: Science/Research',
-            'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 3',
         ],
         keywords='dune physics',
         packages=['reco3d'],
-        install_requires=['pytest']
+        install_requires=['pytest', 'h5py', 'numpy']
 )

--- a/tests/test_converters/test_larpix_converters.py
+++ b/tests/test_converters/test_larpix_converters.py
@@ -1,0 +1,100 @@
+import pytest
+import h5py
+import os
+from reco3d.converters.larpix_converters import (region_ref, LArPixHDF5Converter)
+from reco3d.tools.options import OptionsTool
+from reco3d.types.larpix_types import (Hit, Event, Track)
+
+def test_LArPixHDF5Converter():
+    # test init
+    opts = OptionsTool({'filename':'test.h5'})
+    c = LArPixHDF5Converter(opts)
+    assert c.is_open == False
+    assert c.datafile is None
+    assert c.read_idx == {'hits':0, 'events':0, 'tracks':0}
+    assert c.write_idx == {'hits':0, 'events':0, 'tracks':0}
+
+    try:
+        # test opening file
+        c.open()
+        assert c.is_open == True
+        assert type(c.datafile) == h5py.File
+        for dataset_name in c.rev_type_lookup.keys():
+            assert c.write_idx[dataset_name] == 0
+
+        test_hit0 = Hit(1,2,3,4,5)
+        test_hit1 = Hit(5,4,3,2,1)
+        test_track = Track([test_hit0], 1, 2, 3, 4)
+        test_event = Event(1, [test_hit0], reco_objs=[test_track])
+
+        # test writing hit
+        c.write(test_hit0)
+        c.write(test_hit1)
+        assert c.write_idx['hits'] == 2
+        assert c.datafile['hits'].shape[0] == 2
+        expected = c.reco3d_type_to_hdf5(test_hit0)
+        for name in c.datafile['hits'][0].dtype.names:
+            if bool(c.datafile['hits'][0][name]):
+                # ignore region references
+                assert c.datafile['hits'][0][name] == expected[name]
+        assert bool(c.datafile['hits'][0]['track_ref']) == False
+        assert bool(c.datafile['hits'][0]['event_ref']) == False
+
+        # test writing track
+        c.write(test_track)
+        assert c.write_idx['hits'] == 3
+        assert c.write_idx['tracks'] == 1
+        assert c.datafile['hits'].shape[0] == 3
+        assert c.datafile['tracks'].shape[0] == 1
+        expected = c.reco3d_type_to_hdf5(test_track)
+        for name in c.datafile['tracks'][0].dtype.names:
+            if bool(c.datafile['tracks'][0][name]):
+                if type(c.datafile['tracks'][0][name]) == region_ref:
+                    # ignore references
+                    continue
+                else:
+                    assert c.datafile['tracks'][0][name] == expected[name]
+
+        # test writing event
+        c.write(test_event)
+        assert c.write_idx['hits'] == 4
+        assert c.write_idx['tracks'] == 2
+        assert c.write_idx['events'] == 1
+        assert c.datafile['hits'].shape[0] == 4
+        assert c.datafile['tracks'].shape[0] == 2
+        assert c.datafile['events'].shape[0] == 1
+        expected = c.reco3d_type_to_hdf5(test_event)
+        for name in c.datafile['events'][0].dtype.names:
+            if bool(c.datafile['events'][0][name]):
+                if type(c.datafile['events'][0][name]) == region_ref:
+                    # ignore references
+                    continue
+                else:
+                    assert c.datafile['events'][0][name] == expected[name]
+
+        # test reading hits
+        read_hit0 = c.read(Hit)
+        assert c.read_idx['hits'] == 1
+        assert read_hit0 == test_hit0
+        read_hit1 = c.read(Hit)
+        assert c.read_idx['hits'] == 2
+        assert read_hit1 == test_hit1
+        read_hit3 = c.read(Hit, 0)
+        assert read_hit3 == test_hit0
+        assert c.read_idx['hits'] == 2
+
+        # test reading tracks
+        read_track = c.read(Track)
+        assert read_track == test_track
+        assert c.read_idx['tracks'] == 1
+
+        # test reading events
+        read_event = c.read(Event)
+        assert read_event == test_event
+        assert c.read_idx['events'] == 1
+
+        c.close()
+        assert c.is_open == False
+
+    finally:
+        os.remove('test.h5')


### PR DESCRIPTION
Addresses issue #4.
Changes:
 - Update docstrings in `Converter` modules
 - Implement `LArPixHDF5Converter` to support reading and writing `Hit`, `Event`, and `Track` datatypes to an HDF5 file
 - Add module for misc python tools, `reco3d.tools.python`
 - Importing `reco3d.types` includes both `basic_types` and `larpix_types`
 - Add `Hit`, `Track`, `Event`, `HitCollection`, and `Shower` to `larpix_types`. `Shower` is left un-implemented
 - Update requirements to include `h5py` and `numpy`
 - Add tests for `LArPixHDF5Converter`